### PR TITLE
Adding checkout button to collection page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# Electric Eye Junior Developer Test 1
+
+## Introduction
+
+Welcome, and congratulations! 
+
+This repository contains a fresh copy of Debut, the starter theme provided with every new Shopify store. Debut is great because it's a relatively blank slate for anyone familiar with Shopify, and is easy to understand for a neophyte.
+
+This developer test is also intentionally straight forward. It allows you to get a feel for what it's like to work with us, and us to get an idea of how you solve problems.
+
+Try to have fun with this, and feel free to [reach out with any questions](mailto:mike@electriceye.io) you might have.
+
+Let's get started.
+
+## Prerequisites
+
+Before starting, ensure you have [ThemeKit](https://shopify.github.io/themekit/), [Git](https://git-scm.com/), and a text editor like [VSCode](https://code.visualstudio.com/) installed on your machine.
+
+You should also have a mild understanding of Shopify's [theme settings](https://shopify.dev/docs/themes/settings), [Liquid template language](https://shopify.github.io/liquid/), [Ajax API](https://shopify.dev/docs/themes/ajax-api), and are familiar with the [git workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow).
+
+Finally, as this is a frontend developer role, you should be comfortable writing Javascript, CSS, and HTML.
+
+## Setup Instructions
+
+1. Create a [Shopify partners](https://www.shopify.com/partners) account
+1. Create a [development store](https://help.shopify.com/en/partners/dashboard/managing-stores/development-stores)
+1. Import the provided `products.csv`
+1. Create a [private app](https://help.shopify.com/en/manual/apps/private-apps) for ThemeKit
+    - Check out [this guide](https://www.shopify.com/partners/blog/95401862-3-simple-steps-for-setting-up-a-local-shopify-theme-development-environment)
+1. Create a new Git repository with this code
+    - Github or BitBucket preferred
+    - Can be public or private
+1. Create a development branch off of master
+1. Complete the requirements 
+    - Within your dev store
+    - Using the provided Debut theme (what this codebase is)
+1. Review/QA code against evaluation criteria
+1. Create a pull request into the master branch
+1. Share link or provide access to your repo
+1. Share development store URL
+
+## Scenario 
+
+Imagine you are already on our team, and a client request comes in. They want the ability to show or hide a "buy now" button on their collection pages, allowing users to buy a product and go to checkout immediately.
+
+Furthermore, the client is requesting the ability for that button to either direct the customer directly to checkout ("buy now" button), or add the product to cart and allow the customer to continue shopping. This would mimic how the add to cart button works on product detail pages.
+
+The additional request is deemed by the team to be out of scope for the initial build ("Phase 1"). We agree that we will only accomplish this if time allows. If not, we will push it to a "Phase 2" rollout. The time limit we put on this is 10 hours.
+
+## Requirements
+
+Keeping in mind our time constraint, start with completing Phase 1, and then move on to Phase 2. You should be 90% there after completing Phase 1; keep that in mind, and try to keep your code [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) with Phase 2.
+
+The requirements for each phase are as follows:
+
+### Phase 1
+
+- Create a new "Collection" section in the Shopify theme customize view, under "Theme settings"
+- This new setting section contains a toggle for enabling our new buy now feature
+- On collection pages, a "buy now" button shows under each product when the toggle is on
+- When buy now is clicked, the browser is redirected to checkout with the chosen product in the cart
+
+### Phase 2
+
+- Create a second toggle to change the button to "add to cart"
+- The "buy now" button under each product changes to an "add to cart" button when both toggles are on
+- When add to cart is clicked, the product is added to the cart, and the browser does not redirect
+- Ideally, the existing functionality for adding to cart on a product detail page is replicated
+    - Cart size counter in the header updates
+    - A small modal displays with information about the newly added product
+    - Bonus points for handling the error the same way as well
+
+## Evaluation Criteria
+
+- Code is well organized, formatted, and documented
+    - We should be able to read through your pull request and understand what's going on
+    - Code is DRY
+    - Spaghetti belongs in the kitchen, not in code
+- Progression through the request
+    - We will not "dock points" if you only accomplish one feature, however, you should at least complete Phase 1
+- Brass tacks: **does your code work?**
+
+## Tips
+
+When working with an existing theme, it's best to follow the established standards already in place. However, in instances where you are creating a standalone feature, your best bet is to encapsulate that feature into its own file(s). This keeps your code separate from the theme's base code, making it easier to find, modify, or remove in the future. This is usually accomplished with a [snippet](https://www.shopify.com/partners/blog/88186566-tips-for-using-snippets-in-your-shopify-theme).
+
+More importantly, you can access global theme settings within snippets, using a [Liquid object](https://shopify.dev/docs/themes/liquid/reference/objects). You can also include  CSS `<style>` tags and JS `<script>` tags in snippets, as well as utilize Liquid objects within those tags. Your text editor might show it's concerns, but it's valid, and encouraged.
+
+One thing note about Debut (and many premium Shopify themes): both [jQuery](https://api.jquery.com/) and [Lodash](https://lodash.com/) are deeply integrated into it's codebase. This is controversial to some, but I say if it's already included as part of the stack, it's fair game to use for a new feature.
+
+## Parting Thoughts
+
+Remember that everyone works a little differently, and there truly is no right answer to any one problem. The way you solve a problem today, might not be how you'd do it the next time around. Be kind to yourself; don't get lost in finding the perfect solution, and forget to come up with one at all. As a Great Programming Sage once said: **_"Today's code is tomorrow's trash"_**.
+
+Happy coding! -MW

--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -3738,7 +3738,7 @@ $color-blankstate-background: rgba($color-body-text, 0.1);
   padding-right: 5px;
   white-space: normal;
   margin-top: 0;
-  margin-bottom: 10px;
+  margin-bottom: 25px;
   min-height: 44px;
 
   .product-single--small-media &,

--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -2906,6 +2906,7 @@ hr {
 
 .grid-view-item {
   margin: 0 auto $section-spacing-small;
+  height: 35vh;
   .custom__item & {
     margin-bottom: 0;
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1338,5 +1338,16 @@
         "default": true
       }
     ]
-  }
+  },
+  {
+    "name": "Collection checkout button",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "show_checkout_button",
+        "label": "Show buy now button",
+        "default": false
+      }
+      ]
+   }
 ]

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1347,6 +1347,12 @@
         "id": "show_checkout_button",
         "label": "Show buy now button",
         "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "add_to_cart_change",
+        "label": "Change button to add to cart",
+        "default": false
       }
       ]
    }

--- a/sections/collection-template.liquid
+++ b/sections/collection-template.liquid
@@ -138,7 +138,7 @@
       <ul class="grid grid--uniform{% if collection.products_count > 0 %} grid--view-items{% endif %}">
         {% for product in collection.products %}
           <li class="grid__item grid__item--{{section.id}} {{ grid_item_width }}">
-            {% include 'product-card-grid', max_height: max_height, product: product, show_vendor: section.settings.show_vendor %}
+            {% include 'product-card-grid', max_height: max_height, product: product, show_vendor: section.settings.show_vendor, show_button: settings.show_checkout_button %}
           </li>
         {% else %}
           {% comment %}

--- a/sections/collection-template.liquid
+++ b/sections/collection-template.liquid
@@ -1,10 +1,10 @@
 {% case section.settings.grid %}
   {% when 2 %}
-    {%- assign max_height = 530 -%}
+    {%- assign max_height = 190 -%}
   {% when 3 %}
-    {%- assign max_height = 345 -%}
+    {%- assign max_height = 180 -%}
   {% when 4 %}
-    {%- assign max_height = 250 -%}
+    {%- assign max_height = 230 -%}
   {% when 5 %}
     {%- assign max_height = 195 -%}
 {% endcase %}

--- a/snippets/collection-button.liquid
+++ b/snippets/collection-button.liquid
@@ -15,9 +15,9 @@
     {% form 'product', product, class:form_classes, novalidate: 'novalidate', data-product-form: '' %}
         <select name="id" id="ProductSelect-{{ section.id }}" class="product-form__variants no-js">
             {% for variant in product.variants %}
-            <option value="{{ variant.id }}" {%- if variant == current_variant %} selected="selected" {%- endif -%}>
-                {{ variant.title }}  {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
-            </option>
+                <option value="{{ variant.id }}" {%- if variant == current_variant %} selected="selected" {%- endif -%}>
+                    {{ variant.title }}  {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
+                </option>
             {% endfor %}
         </select>
         <div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden{% if section.settings.enable_payment_button %} product-form__error-message-wrapper--has-payment-button{% endif %}"
@@ -33,7 +33,7 @@
                     <button type="submit" name="add"
                         {% unless current_variant.available %} aria-disabled="true"{% endunless %}
                         aria-label="{% unless current_variant.available %}{{ 'products.product.sold_out' | t }}{% else %}{{ 'products.product.add_to_cart' | t }}{% endunless %}"
-                        class="btn product-form__cart-submit"
+                        class="btn product-form__cart-submit btn--secondary-accent"
                         {% if settings.enable_ajax %}aria-haspopup="dialog"{% endif %}
                         data-add-to-cart>
                         <span data-add-to-cart-text>

--- a/snippets/collection-button.liquid
+++ b/snippets/collection-button.liquid
@@ -1,6 +1,8 @@
 {% comment %}
-    Form used for buy it now button on product template 
-    Takes buyer directly to checkout page with item
+    Toggle between "buy it now" and "add to cart" button based on the theme settings
+    Functionality: 
+    - When buy it now is clicked, the browser is redirected to checkout with the chosen product in the cart
+    - When add to cart is clicked, the product is added to the cart, and the browser does not redirect
 {% endcomment %}
 
 {%- assign current_variant = product.selected_or_first_available_variant -%}
@@ -11,7 +13,6 @@
         data-section-type="product"
         data-enable-history-state="true"
         data-ajax-enabled="{{ settings.enable_ajax }}">
-
     {% form 'product', product, class:form_classes, novalidate: 'novalidate', data-product-form: '' %}
         <select name="id" id="ProductSelect-{{ section.id }}" class="product-form__variants no-js">
             {% for variant in product.variants %}
@@ -27,11 +28,34 @@
             {% include 'icon-error' %}
             <span class="product-form__error-message" data-error-message>{{ 'products.product.quantity_minimum_message' | t }}</span>
         </div>
-
         <div class="product-form__controls-group product-form__controls-group--submit">
             <div class="product-form__item product-form__item--submit" >
-                {{ form | payment_button }}
+                {% if settings.add_to_cart_change %}
+                    <button type="submit" name="add"
+                        {% unless current_variant.available %} aria-disabled="true"{% endunless %}
+                        aria-label="{% unless current_variant.available %}{{ 'products.product.sold_out' | t }}{% else %}{{ 'products.product.add_to_cart' | t }}{% endunless %}"
+                        class="btn product-form__cart-submit"
+                        {% if settings.enable_ajax %}aria-haspopup="dialog"{% endif %}
+                        data-add-to-cart>
+                        <span data-add-to-cart-text>
+                            {{ 'products.product.add_to_cart' | t }}
+                        </span>
+                        <span class="hide" data-loader>
+                            {% include 'icon-spinner' %}
+                        </span>
+                    </button>
+                {% else %}
+                    {% unless current_variant.available %}
+                        <button aria-disabled="true" class="btn product-form__cart-submit">BUY IT NOW</button>
+                    {% else %}
+                        {{ form | payment_button }}
+                    {% endunless %}
+                {% endif %}
             </div>
         </div>
     {% endform %}
 </div>
+
+<script type="application/json" id="ProductJson-{{ section.id }}">
+    {{ product | json }}
+</script>

--- a/snippets/collection-button.liquid
+++ b/snippets/collection-button.liquid
@@ -7,8 +7,7 @@
 
 {%- assign current_variant = product.selected_or_first_available_variant -%}
 
-<div class="product-template__container page-width"
-        id="ProductSection-{{ section.id }}"
+<div id="ProductSection-{{ section.id }}"
         data-section-id="{{ section.id }}"
         data-section-type="product"
         data-enable-history-state="true"

--- a/snippets/collection-button.liquid
+++ b/snippets/collection-button.liquid
@@ -1,0 +1,37 @@
+{% comment %}
+    Form used for buy it now button on product template 
+    Takes buyer directly to checkout page with item
+{% endcomment %}
+
+{%- assign current_variant = product.selected_or_first_available_variant -%}
+
+<div class="product-template__container page-width"
+        id="ProductSection-{{ section.id }}"
+        data-section-id="{{ section.id }}"
+        data-section-type="product"
+        data-enable-history-state="true"
+        data-ajax-enabled="{{ settings.enable_ajax }}">
+
+    {% form 'product', product, class:form_classes, novalidate: 'novalidate', data-product-form: '' %}
+        <select name="id" id="ProductSelect-{{ section.id }}" class="product-form__variants no-js">
+            {% for variant in product.variants %}
+            <option value="{{ variant.id }}" {%- if variant == current_variant %} selected="selected" {%- endif -%}>
+                {{ variant.title }}  {%- if variant.available == false %} - {{ 'products.product.sold_out' | t }}{% endif %}
+            </option>
+            {% endfor %}
+        </select>
+        <div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden{% if section.settings.enable_payment_button %} product-form__error-message-wrapper--has-payment-button{% endif %}"
+            data-error-message-wrapper
+            role="alert">
+            <span class="visually-hidden">{{ 'general.accessibility.error' | t }} </span>
+            {% include 'icon-error' %}
+            <span class="product-form__error-message" data-error-message>{{ 'products.product.quantity_minimum_message' | t }}</span>
+        </div>
+
+        <div class="product-form__controls-group product-form__controls-group--submit">
+            <div class="product-form__item product-form__item--submit" >
+                {{ form | payment_button }}
+            </div>
+        </div>
+    {% endform %}
+</div>

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -53,5 +53,7 @@
     Show onlys when the toggle is on for the "show buy now button" under Collection checkout button in theme settings
 {% endcomment %}
 {% if show_button%}
-  <button class="btn">Buy Now</button>
+
+  {% include 'collection-button' %}
+
 {% endif %}

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -48,3 +48,10 @@
   {% include 'product-price-listing', product: product, show_vendor: show_vendor %}
 
 </div>
+{% comment %}
+    Shows a "buy now" button under each product on collection pages.
+    Show onlys when the toggle is on for the "show buy now button" under Collection checkout button in theme settings
+{% endcomment %}
+{% if show_button%}
+  <button class="btn">Buy Now</button>
+{% endif %}

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -4,7 +4,7 @@
     - max_height: {Number} Maximum height of the product's image (required)
     - product: {Object} Product Liquid object (required)
     - show_vendor: {Boolean} Show the product's vendor depending on the section setting (optional)
-    - show_button: {Boolean} Show the "buy it now" or "add to cart" button below depending on the section setting (optional)
+    - show_button: {Boolean} Show the "buy it now" or "add to cart" button below each product depending on theme settings (optional)
 
     Usage:
     {% include 'product-card-grid', max_height: max_height, product: product, show_vendor: section.settings.show_vendor, show_button: settings.show_checkout_button %}

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -4,9 +4,10 @@
     - max_height: {Number} Maximum height of the product's image (required)
     - product: {Object} Product Liquid object (required)
     - show_vendor: {Boolean} Show the product's vendor depending on the section setting (optional)
+    - show_button: {Boolean} Show the "buy it now" or "add to cart" button below depending on the section setting (optional)
 
     Usage:
-    {% include 'product-card-grid', max_height: max_height, product: product, show_vendor: section.settings.show_vendor %}
+    {% include 'product-card-grid', max_height: max_height, product: product, show_vendor: section.settings.show_vendor, show_button: settings.show_checkout_button %}
 {% endcomment %}
 <div class="grid-view-item{% unless product.available %} grid-view-item--sold-out{% endunless %} product-card">
   <a class="grid-view-item__link grid-view-item__image-container full-width-link" href="{{ product.url | within: collection }}">
@@ -48,12 +49,6 @@
   {% include 'product-price-listing', product: product, show_vendor: show_vendor %}
 
 </div>
-{% comment %}
-    Shows a "buy now" button under each product on collection pages.
-    Show onlys when the toggle is on for the "show buy now button" under Collection checkout button in theme settings
-{% endcomment %}
-{% if show_button%}
-
+{% if show_button %}
   {% include 'collection-button' %}
-
 {% endif %}


### PR DESCRIPTION
 Toggle between "buy it now" and "add to cart" button based on the theme settings. When buy it now is clicked, the browser is redirected to checkout with the chosen product in the cart. When add to cart is clicked, the product is added to the cart, and the browser does not redirect.